### PR TITLE
module translated() extended to process multiple offset vectors

### DIFF
--- a/relativity.scad
+++ b/relativity.scad
@@ -707,13 +707,17 @@ $outward = [0,0,0];
 function hadamard(v1,v2) = [v1.x*v2.x, v1.y*v2.y, v1.z*v2.z];
 
 // form repeating patterns through translation
-module translated(offset, n=[1], class="*"){
-	show(class)
-	for(i=n)
-		_translate(offset*i)
-			children();
-	hide(class)
-		children();
+module translated(offsets, n=[1], class="*"){
+	offsets = len(offsets.x) == undef && offsets.x != undef? [offsets] : offsets;
+	for(offset=offsets)
+	{
+        show(class)
+        for(i=n)
+            _translate(offset*i)
+                children();
+        hide(class)
+            children();
+    }
 }
 
 // form radially symmetric objects around the z axis


### PR DESCRIPTION
Extended the translated() module to process multiple offset vectors as input.
Some modules are able to use multiple vectors as inputs already. Like orient() or align(). Also the align() module is very similar to the translated() module (only that translated doesn't need a parent) but multiple offset vectors weren't available.

Multiple offset vectors with the translated() module is also very powerful! 😄 

The other "transform" modules should also be able to handle multiple input vectors (perhaps more pull requests will follow... 😉 ).