### PR TITLE
module rotated() extended to process multiple offset vectors

### DIFF
--- a/relativity.scad
+++ b/relativity.scad
@@ -717,13 +717,17 @@ module translated(offset, n=[1], class="*"){
 }
 
 // form radially symmetric objects around the z axis
-module rotated(offset, n=[1], class="*"){
-	show(class)
-	for(i=n)
-		rotate(offset*i)
-			children();
-	hide(class)
-		children();
+module rotated(offsets, n=[1], class="*"){
+	offsets = len(offsets.x) == undef && offsets.x != undef? [offsets] : offsets;
+	for(offset=offsets)
+	{
+        show(class)
+        for(i=n)
+            rotate(offset*i)
+                children();
+        hide(class)
+            children();
+    }
 }
 
 // form bilaterally symmetric objects using the mirror() function


### PR DESCRIPTION
Extended the rotated() module to process multiple offset vectors as input.

The rotated() module doesn't need multiple offsets as much as the translated() module, but I think it's good to keep the module signatures (and possibilities) as similar as possible.

More pull requests for more modules will follow... 😉  